### PR TITLE
Update for version 2.4 compatability, git add exploitkit-24.bro! :D

### DIFF
--- a/exploitkit/exploitkit-24.bro
+++ b/exploitkit/exploitkit-24.bro
@@ -1,0 +1,69 @@
+module ExploitKit;
+
+# This version makes ExploitKit compatable with Bro 2.4 by switching to using file_sniff and the fa_metadata type.
+# Previous versions no longer work as mime_type is not a field of the fa_file record (as of Bro 2.4 release).
+
+# One of the many ways to look for Exploit Kit/drive-by behavior. By default, this script looks for
+# a common exploit type: Java JAR (zip), Java Applet, or PDF that precedes a DOS executable. The 
+# behavior is tracked by source IP and a 2min window is allowed for an exploit type and exec to be
+# seen. Additionally, all DOS executables downloaded via HTTP with a User-Agent that contains 'Java/'
+# will be flagged.
+#
+# Notices are generated for the suspicious file combination, and for the JVM downloading executable
+# content.
+#
+# Mike (sooshie@gmail.com)
+
+global monitored_hosts: table[addr] of set[string] &create_expire=2mins &synchronized &mergeable;
+
+export {
+    redef enum Notice::Type += { ExploitKit::SuspiciousDownloads, ExploitKit::JVMDownload };
+
+    const exe_file_types: set[string] = {
+        "application/x-dosexec",
+    } &redef;
+
+    const exploit_file_types: set[string] = {
+        "application/pdf",
+        "application/zip",
+        "application/x-java-applet",
+    } &redef;
+}
+
+event file_sniff(f: fa_file , meta: fa_metadata )
+    {
+    if ( meta?$mime_type )
+        {
+        if ( meta$mime_type in exe_file_types )
+            {
+            for ( cid in f$conns )
+                {
+                local s = "";
+                if ( f$conns[cid]$http?$current_entity && f$conns[cid]$http$current_entity?$filename )
+                    s = fmt("Filename: %s", f$conns[cid]$http$current_entity$filename);    
+                if ( cid$orig_h in monitored_hosts )
+                    { 
+                    local files = "";
+                    for ( fi in monitored_hosts[cid$orig_h] ) { files += fmt("%s, ", fi); }
+                    local message = fmt("Suspicious File Combination:  %s%s", files, meta$mime_type);
+                    NOTICE([$note=ExploitKit::SuspiciousDownloads, $msg=message, $sub=s, $conn=f$conns[cid]]);
+                    }
+                if ( f$conns[cid]?$http && f$conns[cid]$http?$user_agent && ( strstr(f$conns[cid]$http$user_agent, "Java/") != 0 ) )
+                    {
+                    message = fmt("JVM EXE Download: %s", meta$mime_type);
+                    NOTICE([$note=ExploitKit::JVMDownload, $msg=message, $sub=s, $conn=f$conns[cid]]);
+                    }
+                }
+            }
+        if ( meta$mime_type in exploit_file_types )
+            {
+            for ( cid in f$conns )
+                {
+                if ( cid$orig_h !in monitored_hosts )
+                    monitored_hosts[cid$orig_h] = set();
+                add(monitored_hosts[cid$orig_h][meta$mime_type]);
+                }
+            }
+        }
+    return;
+    }


### PR DESCRIPTION
Bro 2.4 no longer includes mime_type in the fa_file record. To reference mime_type when a file is detected, I have switched the event to file_sniff, which takes an fa_metadata argument, including the mime_type field. I have added this as a different file in case users of the script don't find it obvious that this is for 2.4 support. It might be a good idea to create a 2.3 folder and move things around, leaving this as the new default. Let me know if you have any questions.

Cheers!
Steve